### PR TITLE
[X86][ISel] Use 64-bit src for MOVSX64rr32 instead of 32-bit

### DIFF
--- a/llvm/lib/Target/X86/X86InstrCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrCompiler.td
@@ -1638,6 +1638,11 @@ def : Pat<(sext_inreg GR16:$src, i8),
            (EXTRACT_SUBREG (MOVSX32rr8 (EXTRACT_SUBREG GR16:$src, sub_8bit)),
              sub_16bit)>;
 
+#ifdef UNIFICO_INSTR_EXTENSION
+def : Pat<(i64 (sext GR32:$src)),
+          (MOVSX64rr32 (INSERT_SUBREG (i64 (IMPLICIT_DEF)), GR32:$src, sub_32bit))>;
+#endif
+
 def : Pat<(sext_inreg GR64:$src, i32),
           (MOVSX64rr32 (EXTRACT_SUBREG GR64:$src, sub_32bit))>;
 def : Pat<(sext_inreg GR64:$src, i16),

--- a/llvm/lib/Target/X86/X86InstrExtension.td
+++ b/llvm/lib/Target/X86/X86InstrExtension.td
@@ -153,10 +153,19 @@ def MOVSX64rm16: RI<0xBF, MRMSrcMem, (outs GR64:$dst), (ins i16mem:$src),
                     "movs{wq|x}\t{$src, $dst|$dst, $src}",
                     [(set GR64:$dst, (sextloadi64i16 addr:$src))]>,
                     TB, Sched<[WriteALULd]>;
+
+#ifndef UNIFICO_INSTR_EXTENSION
 def MOVSX64rr32: RI<0x63, MRMSrcReg, (outs GR64:$dst), (ins GR32:$src),
                     "movs{lq|xd}\t{$src, $dst|$dst, $src}",
                     [(set GR64:$dst, (sext GR32:$src))]>,
                     Sched<[WriteALU]>, Requires<[In64BitMode]>;
+#else
+def MOVSX64rr32: RI<0x63, MRMSrcReg, (outs GR64:$dst), (ins GR64:$src),
+                    "movs{lq|xd}\t{$src, $dst|$dst, $src}",
+                    []>,
+                    Sched<[WriteALU]>, Requires<[In64BitMode]>;
+#endif
+
 def MOVSX64rm32: RI<0x63, MRMSrcMem, (outs GR64:$dst), (ins i32mem:$src),
                     "movs{lq|xd}\t{$src, $dst|$dst, $src}",
                     [(set GR64:$dst, (sextloadi64i32 addr:$src))]>,

--- a/llvm/lib/Target/X86/X86InstrInfo.td
+++ b/llvm/lib/Target/X86/X86InstrInfo.td
@@ -3443,7 +3443,12 @@ def : InstAlias<"movsx\t{$src, $dst|$dst, $src}", (MOVSX32rr8 GR32:$dst, GR8:$sr
 def : InstAlias<"movsx\t{$src, $dst|$dst, $src}", (MOVSX32rr16 GR32:$dst, GR16:$src), 0, "att">;
 def : InstAlias<"movsx\t{$src, $dst|$dst, $src}", (MOVSX64rr8 GR64:$dst, GR8:$src), 0, "att">;
 def : InstAlias<"movsx\t{$src, $dst|$dst, $src}", (MOVSX64rr16 GR64:$dst, GR16:$src), 0, "att">;
+
+#ifndef UNIFICO_INSTR_EXTENSION
 def : InstAlias<"movsx\t{$src, $dst|$dst, $src}", (MOVSX64rr32 GR64:$dst, GR32:$src), 0, "att">;
+#else
+def : InstAlias<"movsx\t{$src, $dst|$dst, $src}", (MOVSX64rr32 GR64:$dst, GR64:$src), 0, "att">;
+#endif
 
 // movzx aliases
 def : InstAlias<"movzx\t{$src, $dst|$dst, $src}", (MOVZX16rr8 GR16:$dst, GR8:$src), 0, "att">;


### PR DESCRIPTION
The equivalent AArch64 instruction that is used to lower `ISD:SIGN_EXTEND` is `SBFMXri`, which operates on
64-bit operands. This means that it creates a 64-bit subregister and then copies the original 32-bit register using `INSERT_SUBREG`.

However, after register coalescing, this copy may be eliminated, leaving only the 64-bit virtual register. If later this register is spilled, then a 64-bit slot is created, in contrast to X86 which would create a 32-bit slot. Therefore, we need to emulate the same behavior in X86.

We now add the TableGen macro `-DUNIFICO_INSTR_EXTENSION`.