### PR TITLE
[X86][Isel] Fix bug when using `MOVSX64rr32` for in-place sign extension

### DIFF
--- a/llvm/lib/Target/X86/X86InstrCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrCompiler.td
@@ -1644,7 +1644,11 @@ def : Pat<(i64 (sext GR32:$src)),
 #endif
 
 def : Pat<(sext_inreg GR64:$src, i32),
+#ifndef UNIFICO_INSTR_EXTENSION
           (MOVSX64rr32 (EXTRACT_SUBREG GR64:$src, sub_32bit))>;
+#else
+          (MOVSX64rr32 GR64:$src)>;
+#endif
 def : Pat<(sext_inreg GR64:$src, i16),
           (MOVSX64rr16 (EXTRACT_SUBREG GR64:$src, sub_16bit))>;
 def : Pat<(sext_inreg GR64:$src, i8),


### PR DESCRIPTION
Fixes a previous patch:
https://github.com/blackgeorge-boom/llvm-unifico/pull/1

which did not take into account the use of `MOVSX64rr32` with `sign_extend_inreg`. Since the (only) operand of this MIR instruction is a 64-bit value, we do not have to pass a subregister as the argument.

Addresses: https://github.com/systems-nuts/unifico/issues/296