### PR TITLE
[X86] Do not move directly 8-,16-, and 32-bit non-zero immediates to memory

### DIFF
--- a/llvm/lib/Target/X86/X86InstrInfo.td
+++ b/llvm/lib/Target/X86/X86InstrInfo.td
@@ -1060,6 +1060,14 @@ def relocImm32_su : PatLeaf<(i32 relocImm), [{
     return !shouldAvoidImmediateInstFormsForSizeExceptZero(N);
 }]>;
 
+def relocImm8_su_for_mov : PatLeaf<(i8 relocImm), [{
+    return useImmediateInstForms(N);
+}]>;
+
+def relocImm16_su_for_mov : PatLeaf<(i16 relocImm), [{
+    return useImmediateInstForms(N);
+}]>;
+
 def relocImm32_su_for_mov : PatLeaf<(i32 relocImm), [{
     return useImmediateInstForms(N);
 }]>;
@@ -1079,6 +1087,10 @@ def i64relocImmSExt8_su : PatLeaf<(i64relocImmSExt8), [{
 }]>;
 def i64relocImmSExt32_su : PatLeaf<(i64relocImmSExt32), [{
     return !shouldAvoidImmediateInstFormsForSize(N);
+}]>;
+
+def i64relocImmSExt32_su_for_mov : PatLeaf<(i64relocImmSExt32), [{
+    return useImmediateInstForms(N);
 }]>;
 
 // i64immZExt32 predicate - True if the 64-bit immediate fits in a 32-bit
@@ -1573,16 +1585,16 @@ def MOV32ri_alt : Ii32<0xC7, MRM0r, (outs GR32:$dst), (ins i32imm:$src),
 let SchedRW = [WriteStore] in {
 def MOV8mi  : Ii8 <0xC6, MRM0m, (outs), (ins i8mem :$dst, i8imm :$src),
                    "mov{b}\t{$src, $dst|$dst, $src}",
-                   [(store (i8 relocImm8_su:$src), addr:$dst)]>;
+                   [(store (i8 relocImm8_su_for_mov:$src), addr:$dst)]>;
 def MOV16mi : Ii16<0xC7, MRM0m, (outs), (ins i16mem:$dst, i16imm:$src),
                    "mov{w}\t{$src, $dst|$dst, $src}",
-                   [(store (i16 relocImm16_su:$src), addr:$dst)]>, OpSize16;
+                   [(store (i16 relocImm16_su_for_mov:$src), addr:$dst)]>, OpSize16;
 def MOV32mi : Ii32<0xC7, MRM0m, (outs), (ins i32mem:$dst, i32imm:$src),
                    "mov{l}\t{$src, $dst|$dst, $src}",
                    [(store (i32 relocImm32_su_for_mov:$src), addr:$dst)]>, OpSize32;
 def MOV64mi32 : RIi32S<0xC7, MRM0m, (outs), (ins i64mem:$dst, i64i32imm:$src),
                        "mov{q}\t{$src, $dst|$dst, $src}",
-                       [(store i64relocImmSExt32_su:$src, addr:$dst)]>,
+                       [(store i64relocImmSExt32_su_for_mov:$src, addr:$dst)]>,
                        Requires<[In64BitMode]>;
 } // SchedRW
 


### PR DESCRIPTION
Extends https://github.com/blackgeorge-boom/llvm-project/pull/26 to account for other immediate sizes as well. This prevents emitting move instructions of non-zero immediates directly to memory, but still allows moving them to registers, hence the use of separate pattern leaves of the form `relocImmXX_su_for_mov`.

Addresses: https://github.com/systems-nuts/unifico/issues/304