### PR TITLE
[Isel] Assign the correct register class when emitting a `COPY`

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
@@ -157,11 +157,10 @@ EmitCopyFromReg(SDNode *Node, unsigned ResNo, bool IsClone, bool IsCloned,
   SrcRC = TRI->getMinimalPhysRegClass(SrcReg, VT);
 
   // Figure out the register class to create for the destreg.
-  if (VRBase) {
+  if (TRI->requiresRegClassOfCopiedReg(*MF, SrcReg)) {
+    DstRC = SrcRC;
+  } else if (VRBase) {
     DstRC = MRI->getRegClass(VRBase);
-    if (TRI->requiresRegClassOfCopiedReg(*MF, SrcReg)) {
-      DstRC = SrcRC;
-    }
   } else if (UseRC) {
     assert(TRI->isTypeLegalForClass(*UseRC, VT) &&
            "Incompatible phys register def and uses!");


### PR DESCRIPTION
Extends https://github.com/blackgeorge-boom/llvm-project/pull/53/ to propagate the source register class to the destination not only when copying from a virtual register, but also when emitting any `COPY` during isel.

For example, this now covers the case when we lower `Constant:i32<0>` to `%vr:gpr32temp = COPY $wzr`.