### PR TITLE
[AArch64][ISel] Add flag to control lowering of select

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -386,6 +386,11 @@ def FeatureAdvancedRASplitCost : SubtargetFeature<"advanced-ra-split-cost", "Has
 def FeatureX86FabsFneg : SubtargetFeature<"x86-fabs-fneg", "HasX86FabsFneg",
     "true", "Lower FABS/FNEG similarly to X86.">;
 
+// Whether to lower SELECT the same way as X86, which inverts the operands and the condition
+// to make it compatible with the two-address format.
+def FeatureX86Select : SubtargetFeature<"x86-select", "HasX86Select",
+    "true", "Lower SELECT similarly to X86.">;
+
 //===----------------------------------------------------------------------===//
 // Architectures.
 //

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -143,6 +143,7 @@ protected:
   bool HasCopyZRToTemp = false;
   bool HasAdvancedRASplitCost = false;
   bool HasX86FabsFneg = false;
+  bool HasX86Select = false;
 
   // Arm SVE2 extensions
   bool HasSVE2AES = false;
@@ -400,6 +401,7 @@ public:
   bool avoidWideMul() const { return AvoidWideMul; }
   bool hasCopyZRToTemp() const { return HasCopyZRToTemp; }
   bool hasX86FabsFneg() const { return HasX86FabsFneg; }
+  bool hasX86Select() const { return HasX86Select; }
   // Arm SVE2 extensions
   bool hasSVE2AES() const { return HasSVE2AES; }
   bool hasSVE2SM4() const { return HasSVE2SM4; }


### PR DESCRIPTION
Adds `x86-select` attribute to choose whether to lower SELECT similarly to X86.

Extends: https://github.com/blackgeorge-boom/llvm-unifico/pull/8