### PR TITLE
[X86][ISel] Do now allow global address in addressing mode

### DIFF
--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -515,6 +515,12 @@ def FeatureAvoidSelectToFSETCC: SubtargetFeature<"avoid-select-to-fsetcc",
                                         "AvoidSelectToFSETCC", "true",
                                         "Avoid converting SELECT to FSETCC.">;
 
+// Allow similar addresses to AArch64 as legal.
+// For example, this is useful in loop strength reduction.
+def FeatureAArch64LegalAddress: SubtargetFeature<"aarch64-legal-addr",
+                                        "AArch64LegalAddress", "true",
+                                        "Similar legal addresses as in AArch64.">;
+
 // Bonnell
 def ProcIntelAtom : SubtargetFeature<"", "X86ProcFamily", "IntelAtom", "">;
 // Silvermont

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -28584,6 +28584,11 @@ bool X86TargetLowering::isLegalAddressingMode(const DataLayout &DL,
     return false;
 
   if (AM.BaseGV) {
+
+    // AArch64 bails out here.
+    if (Subtarget.hasAArch64LegalAddress())
+      return false;
+
     unsigned GVFlags = Subtarget.classifyGlobalReference(AM.BaseGV);
 
     // If a reference to this global requires an extra load, we can't fold it.

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -467,6 +467,9 @@ protected:
   /// Avoid converting SELECT to FSETCC
   bool AvoidSelectToFSETCC = false;
 
+  /// Encode similar addressing modes with AArch64
+  bool AArch64LegalAddress = false;
+
   /// What processor and OS we're targeting.
   Triple TargetTriple;
 
@@ -729,6 +732,7 @@ public:
   bool hasSimpleRegOffsetAddr() const { return SimpleRegOffsetAddr; }
   bool forceVectorMemOp() const { return ForceVectorMemOp; }
   bool avoidSelectToFSETCC() const { return AvoidSelectToFSETCC; }
+  bool hasAArch64LegalAddress() const { return AArch64LegalAddress; }
   bool avoidOptimizingMulCase1() const { return AvoidOptimizingMulCase1; }
   bool hasINVPCID() const { return HasINVPCID; }
   bool hasENQCMD() const { return HasENQCMD; }


### PR DESCRIPTION
AArch64 does not support this, so we add a flag to disable it in X86 as well.

Addresses: https://github.com/systems-nuts/unifico/issues/309