### PR TITLE
[regalloc] Remove conditional guards from GPR temp classes

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -234,19 +234,15 @@ def GPR64sp : RegisterClass<"AArch64", [i64], 64, (add GPR64common, SP)> {
 #endif
 }
 
-#ifdef UNIFICO_REGALLOC_RULES
 // GPR register class which only includes 32-bit temporary registers and the zero register.
 // This is useful when we want to assign the zero register to only temporary registers,
 // since for X86 we are using MOV32r0 instead, which for now we only assign to temporary registers.
 // This will be achieved through calling `TargetRegisterInfo::getMinimalPhysRegClass`.
 def GPR32temp : RegisterClass<"AArch64", [i32], 32,
                                 (add W8, W3, W2, W1, W0, W4, W5, W6, W7, W18, W16, W17, WZR)>;
-#endif
 
-#ifdef UNIFICO_REGALLOC_RULES
 def GPR64temp : RegisterClass<"AArch64", [i64], 64,
                                 (add X8, X3, X2, X1, X0, X4, X5, X6, X7, X18, X16, X17, XZR)>;
-#endif
 
 def GPR32sponly : RegisterClass<"AArch64", [i32], 32, (add WSP)>;
 def GPR64sponly : RegisterClass<"AArch64", [i64], 64, (add SP)>;

--- a/llvm/lib/Target/X86/X86RegisterInfo.td
+++ b/llvm/lib/Target/X86/X86RegisterInfo.td
@@ -409,11 +409,9 @@ def GR32 : RegisterClass<"X86", [i32], 32,
                          (add EAX, ECX, EDX, ESI, EDI, EBX, EBP, ESP,
                               R8D, R9D, R10D, R11D, R14D, R15D, R12D, R13D)>;
 
-#ifdef UNIFICO_REGALLOC_RULES
 def GR32temp : RegisterClass<"X86", [i32], 32,
                          (add EAX, ECX, EDX, ESI, EDI,
                               R8D, R9D, R10D, R11D, R14D, R12D, R13D)>;
-#endif
 
 // GR64 - 64-bit GPRs. This oddly includes RIP, which isn't accurate, since
 // RIP isn't really a register and it can't be used anywhere except in an


### PR DESCRIPTION
For the AArch64 GPR32temp/GPR64temp classes and for the X86 GR32temp class, we remove the conditional compilation guards in TableGen, because some of these classes are referenced in the code (even if they are deactivated through the Unifico flags). Because not including them in TableGen will make the compilation fail, we always define these classes in TableGen. Thus, we can decide whether to actually use them or not, through the respective llc flags.