### PR TITLE
[stackmaps][X86] Increase LEA coverage

### DIFF
--- a/llvm/include/llvm/CodeGen/StackTransformTypes.h
+++ b/llvm/include/llvm/CodeGen/StackTransformTypes.h
@@ -309,11 +309,9 @@ private:
 /// MachineStackObject - an object on the stack
 class MachineStackObject : public MachineLiveVal {
 public:
-  MachineStackObject(int Index,
-                     bool Load,
-                     const MachineInstr *DefMI,
-                     bool Ptr = false)
-    : MachineLiveVal(DefMI, Ptr), Index(Index), Load(Load) {}
+  MachineStackObject(int Index, bool Load, const MachineInstr *DefMI,
+                     bool Ptr = false, int Offset = 0)
+      : MachineLiveVal(DefMI, Ptr), Index(Index), Load(Load), Offset(Offset) {}
   MachineStackObject(const MachineStackObject &C)
     : MachineLiveVal(C), Index(C.Index), Load(C.Load) {}
   virtual MachineLiveVal *copy() const
@@ -346,6 +344,11 @@ private:
   /// Are we generating a reference to a stack object or loading a value from
   /// the stack slot?
   bool Load;
+
+  /// The offset from the stack slot index of a stack obect. This is useful for
+  /// machine live values that encode an offset from a stack slot which should
+  /// be added to the offset from the base register when emitting the stackmap.
+  int Offset;
 };
 
 /// ReturnAddress - the return address stored on the stack

--- a/llvm/lib/CodeGen/StackTransformTypes.cpp
+++ b/llvm/lib/CodeGen/StackTransformTypes.cpp
@@ -191,13 +191,19 @@ std::string MachineStackObject::toString() const {
   std::string buf;
   if(Load) buf = "load from ";
   else buf = "reference to ";
-  return buf + "stack slot " + std::to_string(Index);
+  buf += "stack slot " + std::to_string(Index);
+  if (Offset) {
+    buf += " with offset " + std::to_string(Offset);
+  }
+  return buf;
 }
 
 int
 MachineStackObject::getOffsetFromReg(AsmPrinter &AP, unsigned &BR) const {
   const TargetFrameLowering *TFL = AP.MF->getSubtarget().getFrameLowering();
-  return TFL->getFrameIndexReference(*AP.MF, Index, BR);
+  // Calculate the offset of the stack slot and add it to the potential existing
+  // offset of the machine live value.
+  return TFL->getFrameIndexReference(*AP.MF, Index, BR) + this->Offset;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/X86/X86Values.cpp
+++ b/llvm/lib/Target/X86/X86Values.cpp
@@ -89,6 +89,9 @@ MachineLiveVal *X86Values::genLEAInstructions(const MachineInstr *MI) const {
     Size = 8;
 
     if(MI->getOperand(1 + X86::AddrBaseReg).isFI()) {
+      int FI = MI->getOperand(1 + X86::AddrBaseReg).getIndex();
+      int64_t Offset;
+
       // Stack slot address
       if(!isImmOp(MI->getOperand(1 + X86::AddrScaleAmt), 1)) {
         LLVM_DEBUG(dbgs() << "Unhandled scale amount for frame index\n");
@@ -100,14 +103,13 @@ MachineLiveVal *X86Values::genLEAInstructions(const MachineInstr *MI) const {
         break;
       }
 
-      if(!isImmOp(MI->getOperand(1 + X86::AddrDisp), 0)) {
-        LLVM_DEBUG(dbgs() << "Unhandled index register for frame index\n");
+      if (!MI->getOperand(1 + X86::AddrDisp).isImm()) {
+        LLVM_DEBUG(dbgs() << "Unhandled displacement for frame offset\n");
         break;
       }
+      Offset = MI->getOperand(1 + X86::AddrDisp).getImm();
 
-      return new
-        MachineStackObject(MI->getOperand(1 + X86::AddrBaseReg).getIndex(),
-                           false, MI, true);
+      return new MachineStackObject(FI, false, MI, true, Offset);
     }
     else if(isRegOp(MI->getOperand(1 + X86::AddrBaseReg), X86::RIP)) {
       // PC-relative symbol address


### PR DESCRIPTION
Currently, stackmaps do not handle arch-specific values of the form:

```llvm
  %41:gr64 = LEA64r %stack.0.A, 1, $noreg, 48, $noreg
```

where the value is a `MachineStackObject` with non-zero displacement.

We extend `MachineStackObject` with an optional `Offset` field, so that we can encode an additional offset from the frame pointer, apart from the offset of the slot itself.

This is helpful when an arch-specific slot contains a pointer to an array or a struct element, where the start address of the array or struct is stored in another slot index. So, the arch-specific value is a slot index plus an offset.

Closes: https://github.com/blackgeorge-boom/llvm-unifico/issues/25