### PR TITLE
Make call to sanitizeVregs re-entrant

### DIFF
--- a/llvm/include/llvm/CodeGen/StackTransformTypes.h
+++ b/llvm/include/llvm/CodeGen/StackTransformTypes.h
@@ -313,7 +313,7 @@ public:
                      bool Ptr = false, int Offset = 0)
       : MachineLiveVal(DefMI, Ptr), Index(Index), Load(Load), Offset(Offset) {}
   MachineStackObject(const MachineStackObject &C)
-    : MachineLiveVal(C), Index(C.Index), Load(C.Load) {}
+      : MachineLiveVal(C), Index(C.Index), Load(C.Load), Offset(C.Offset) {}
   virtual MachineLiveVal *copy() const
   { return new MachineStackObject(*this); }
 

--- a/llvm/lib/CodeGen/StackTransformMetadata.cpp
+++ b/llvm/lib/CodeGen/StackTransformMetadata.cpp
@@ -286,7 +286,7 @@ class StackTransformMetadata : public MachineFunctionPass {
 
   /// Ensure virtual registers used to generate architecture-specific values
   /// are handled by the stackmap & convert to physical registers
-  void sanitizeVregs(MachineLiveValPtr &LV, MachineInstr *SM) const;
+  unsigned sanitizeVregs(MachineLiveValPtr &LV, MachineInstr *SM) const;
 
   /// Find architecture-specific live values added by the backend
   void findArchSpecificLiveVals();
@@ -1168,9 +1168,10 @@ bool StackTransformMetadata::findAlternateOpLocs() {
 
 /// Ensure virtual registers used to generate architecture-specific values are
 /// handled by the stackmap & convert to physical registers
-void StackTransformMetadata::sanitizeVregs(MachineLiveValPtr &LV,
-                                           MachineInstr *SM) const {
-  if(!LV) return;
+unsigned StackTransformMetadata::sanitizeVregs(MachineLiveValPtr &LV,
+                                               MachineInstr *SM) const {
+  if (!LV)
+    return 0;
   if(LV->isGenerated()) {
     MachineGeneratedVal *MGV = (MachineGeneratedVal *)LV.get();
     const ValueGenInstList &Inst = MGV->getInstructions();
@@ -1207,20 +1208,22 @@ void StackTransformMetadata::sanitizeVregs(MachineLiveValPtr &LV,
             // Give the target a chance to adjust the mask.
             TRI->adjustStackMapLiveOutMask(Mask);
           }
-          return;
+          return 0;
         }
         if (!SMRegs.at(SM).count(RI->getReg())) {
           LLVM_DEBUG(dbgs() << "WARNING: vreg "
                        << TargetRegisterInfo::virtReg2Index(RI->getReg())
                        << " used to generate value not handled in stackmap\n");
+          unsigned UnhandledVreg = RI->getReg();
           LV.reset(nullptr);
-          return;
+          return UnhandledVreg;
         }
         assert(VRM->hasPhys(RI->getReg()) && "Invalid virtual register");
         RI->setReg(VRM->getPhys(RI->getReg()));
       }
     }
   }
+  return 0;
 }
 
 /// Filter out register definitions we've previously seen.
@@ -1328,6 +1331,7 @@ void StackTransformMetadata::findArchSpecificLiveVals() {
         const MachineInstr *DefMI;
         unsigned ChainVreg = Vreg;
         SmallPtrSet<const MachineInstr *, 4> SeenDefs, NewDefs;
+        std::queue<WorkItem> work;
         do {
           getUnseenDefinitions(MRI->def_instr_begin(ChainVreg),
                                SeenDefs, NewDefs);
@@ -1352,12 +1356,24 @@ void StackTransformMetadata::findArchSpecificLiveVals() {
 
           SeenDefs.insert(DefMI);
           MLV = TVG->getMachineValue(DefMI);
-          sanitizeVregs(MLV, MISM);
+          auto UnhandledVreg = sanitizeVregs(MLV, MISM);
 
-          if(MLV) break; // We got a value!
-          else {
+          if (MLV && work.empty())
+            break; // We got a value!
+          if (MLV) {
+            LLVM_DEBUG(dbgs() << "      Defining instruction: ";
+                       MLV->getDefiningInst()->print(dbgs());
+                       dbgs() << "      Value: " << MLV->toString() << "\n");
+
+            MLR.setReg(VRM->getPhys(ChainVreg));
+            MF->addSMArchSpecificLocation(IRSM, MLR, *MLV);
+            CurVregs.emplace(ChainVreg, ValueVecPtr(nullptr));
+            ChainVreg = work.front().Vreg;
+            work.pop();
+          } else {
             // Couldn't get a value, follow the use-def chain
             CopyLocPtr Copy = getCopyLocation(DefMI);
+            // If we have a copy, check the source for a value instead
             if(Copy) {
               switch(Copy->getType()) {
               default: ChainVreg = 0; break;
@@ -1365,8 +1381,16 @@ void StackTransformMetadata::findArchSpecificLiveVals() {
                 ChainVreg = ((RegCopyLoc *)Copy.get())->SrcVreg;
                 break;
               }
-            }
-            else ChainVreg = 0;
+              // As a last resort, check if sanitizeVregs found an unhandled
+              // vreg. If yes, then reset the search you did for the current
+              // vreg, try to find the value for the unhandled vreg, and later
+              // pop the original vreg from the queue and try again.
+            } else if (UnhandledVreg) {
+              work.emplace(ChainVreg, true);
+              ChainVreg = UnhandledVreg;
+              SeenDefs.erase(DefMI);
+            } else
+              ChainVreg = 0;
           }
         } while(TargetRegisterInfo::isVirtualRegister(ChainVreg));
 

--- a/llvm/lib/Target/AArch64/AArch64Values.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Values.cpp
@@ -70,14 +70,16 @@ AArch64Values::genADDInstructions(const MachineInstr *MI) const {
   ValueGenInstList IL;
 
   switch(MI->getOpcode()) {
-  case AArch64::ADDXri:
+  case AArch64::ADDXri: {
+    int64_t Offset;
     if(MI->getOperand(1).isFI()) {
       Index = MI->getOperand(1).getIndex();
-      assert(MI->getOperand(2).isImm() && MI->getOperand(2).getImm() == 0);
+      Offset = MI->getOperand(2).getImm();
       assert(MI->getOperand(3).isImm() && MI->getOperand(3).getImm() == 0);
-      return new MachineStackObject(Index, false, MI, true);
+      return new MachineStackObject(Index, false, MI, true, Offset);
     }
     break;
+  }
   case AArch64::ADDXrr:
     assert(MI->getOperand(1).isReg() && MI->getOperand(2).isReg());
     Reg1 = MI->getOperand(1).getReg();
@@ -138,6 +140,21 @@ AArch64Values::genBitfieldInstructions(const MachineInstr *MI) const {
     }
     return new MachineGeneratedVal(IL, MI, false);
     break;
+  case AArch64::ORRXri: {
+    Size = 8;
+    int64_t Offset;
+    assert(MI->getOperand(1).isReg() && MI->getOperand(2).isImm());
+    Offset = MI->getOperand(2).getImm();
+    if (MI->getOperand(1).isFI()) {
+      int Index = MI->getOperand(1).getIndex();
+      return new MachineStackObject(Index, false, MI, true, Offset);
+    }
+    IL.emplace_back(
+        new RegInstruction<InstType::Set>(MI->getOperand(1).getReg()));
+    IL.emplace_back(new ImmInstruction<InstType::Mask>(Size, Offset));
+    return new MachineGeneratedVal(IL, MI, false);
+    break;
+  }
   default:
     LLVM_DEBUG(dbgs() << "Unhandled bitfield instruction");
     break;
@@ -259,8 +276,10 @@ MachineLiveValPtr AArch64Values::getMachineValue(const MachineInstr *MI) const {
     Val = new MachineImmediate(8, MO->getImm(), MI, false);
     break;
   case AArch64::UBFMXri:
+  case AArch64::ORRXri:
     Val = genBitfieldInstructions(MI);
     break;
+
   default:
     TII =  MI->getParent()->getParent()->getSubtarget().getInstrInfo();
     LLVM_DEBUG(dbgs() << "Unhandled opcode: "


### PR DESCRIPTION
If `sanitizeVregs` finds an unhandled virtual register, it returns it and restarts finding an arch-specific definition for that register. Then, it retries to find the defining instruction for the original register.

This patch also extends stackmap handling for `ADDXri` and `ORRXri`, which can be used to define an offset from a machine stack object.

The issue with the `sanitizeVregs` came up as we were trying to use `sanitizeVregs` over the defining instruction `ORRXri`, which had some source registers that were also not handled by the stackmap.

Closes: https://github.com/blackgeorge-boom/llvm-unifico/issues/28
Closes: https://github.com/blackgeorge-boom/llvm-unifico/issues/29