### PR TITLE
[stackmaps] Fix offset when stackmap is pushed downwards

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -118,6 +118,17 @@ public:
   /// default, this is equal to CurrentFnSym.
   MCSymbol *CurrentFnSymForSize = nullptr;
 
+  /// The symbol used to represent the next instruction after a call for the
+  /// purpose of calculating the correct stackmap offset from the beginning of
+  /// the parent function, which is exactly after the corresponding function
+  /// call. This is supposed to point where execution will happen in the
+  /// destination node after migration. Sometimes the compiler inserts MIR
+  /// instructions between a function call and the corresponding stackmap,
+  /// pushing the stackmap downwards. In this case, to have the correct stackmap
+  /// offset we keep track of the next instruction after the call through a
+  /// temporary symbol.
+  MCSymbol *CurrentAfterCallSymForCSOffset = nullptr;
+
   /// Map global GOT equivalent MCSymbols to GlobalVariables and keep track of
   /// its number of uses by other globals.
   using GOTEquivUsePair = std::pair<const GlobalVariable *, unsigned>;

--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -830,11 +830,16 @@ void StackMaps::recordPcnStackMapOpers(const MachineInstr &MI, uint64_t ID,
   // writers, in their infinite wisdom, decided to abstract multiple assembly
   // instructions into a single machine IR instruction (*ahem* PowerPC *ahem*).
   // Generate an expression to correct for this "feature".
+  //
+  // However, in Unifico, we aren't interested in powerpc, so we don't correct
+  // the offset. We only account for the case where the compiler has inserted
+  // MIR instructions between a call and the stackmap, so we calculate the
+  // offset from the parent function starting not from the stackmap itself
+  // (since it might have been pushed downwards), but from the instruction
+  // directly after the call (tracked by `CurrentAfterCallSymForCSOffset`).
   int RAOffset = AP.getCanonicalReturnAddr(MI.getPrevNode());
-  const MCExpr *RAFixup = MCBinaryExpr::createSub(
-      MCSymbolRefExpr::create(MILabel, OutContext),
-      MCConstantExpr::create(RAOffset, OutContext), OutContext);
-  const MCExpr *CSOffsetExpr = MCBinaryExpr::createSub(RAFixup,
+  const MCExpr *CSOffsetExpr = MCBinaryExpr::createSub(
+      MCSymbolRefExpr::create(AP.CurrentAfterCallSymForCSOffset, OutContext),
       MCSymbolRefExpr::create(AP.CurrentFnSymForSize, OutContext), OutContext);
 
   CSInfos.emplace_back(AP.CurrentFnSym, CSOffsetExpr, ID,

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -1279,6 +1279,14 @@ void AArch64AsmPrinter::EmitInstruction(const MachineInstr *MI) {
   }
 
   EmitToStreamer(*OutStreamer, TmpInst);
+
+  if (MI->isCall()) {
+    /// Emit a label for the instruction after the call, to calculate the
+    /// correct offset for the stackmap later.
+    MCSymbol *MIAfterCallLabel = OutContext.createTempSymbol();
+    CurrentAfterCallSymForCSOffset = MIAfterCallLabel;
+    OutStreamer->EmitLabel(MIAfterCallLabel);
+  }
 }
 
 // Force static initialization.

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -2643,7 +2643,13 @@ void X86AsmPrinter::EmitInstruction(const MachineInstr *MI) {
       }
     }
 
+    /// Emit a label for the instruction after the call, to calculate the
+    /// correct offset for the stackmap later.
     OutStreamer->EmitInstruction(TmpInst, getSubtargetInfo());
+    MCSymbol *MIAfterCallLabel = OutContext.createTempSymbol();
+    CurrentAfterCallSymForCSOffset = MIAfterCallLabel;
+    OutStreamer->EmitLabel(MIAfterCallLabel);
+
     return;
   }
 


### PR DESCRIPTION
The correct stackmap offset from the beginning of the parent function is exactly after the corresponding function call. This is supposed to point where execution will happen in the destination node after migration.

Sometimes the compiler inserts MIR instructions between a function call and the corresponding stackmap, pushing the stackmap downwards.

```llvm
BL @func1 ...
%14:gpr32temp = LDRWui %stack.0, 0 ...
ADJCALLSTACKUP 0, 0, implicit-def $sp ...
ADJCALLSTACKDOWN 0, 0, implicit-def $sp ...
PCN_STACKMAP 3, 0, %14:gpr32temp ...
```

In this case, to have the correct stackmap offset, we keep track of the next instruction after the call through a temporary symbol. Then, the correct stackmap offset from the parent function becomes the offset of this symbol, and not the offset of the stackmap itself.