### PR TITLE
[layout][AArch64] Add RegisterBank info for the GPR32temp class

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterBankInfo.cpp
@@ -256,6 +256,8 @@ const RegisterBank &AArch64RegisterBankInfo::getRegBankFromRegClass(
   case AArch64::tcGPR64RegClassID:
   case AArch64::WSeqPairsClassRegClassID:
   case AArch64::XSeqPairsClassRegClassID:
+  case AArch64::GPR32tempRegClassID:
+  case AArch64::GPR32common_and_GPR32tempRegClassID:
     return getRegBank(AArch64::GPRRegBankID);
   case AArch64::CCRRegClassID:
     return getRegBank(AArch64::CCRegBankID);


### PR DESCRIPTION
This came up when passing -O0 to `llc`, since normally we were passing -O1 or -O2 (default and identical to -O1), while compiling IS.